### PR TITLE
Fix deprecated assignment method in 'ball_hit' column to resolve SettingWithCopyWarning

### DIFF
--- a/trackers/ball_tracker.py
+++ b/trackers/ball_tracker.py
@@ -47,7 +47,7 @@ class BallTracker:
                         change_count+=1
             
                 if change_count>minimum_change_frames_for_hit-1:
-                    df_ball_positions['ball_hit'].iloc[i] = 1
+                    df_ball_positions.loc[i, "ball_hit"] = 1
 
         frame_nums_with_ball_hits = df_ball_positions[df_ball_positions['ball_hit']==1].index.tolist()
 


### PR DESCRIPTION
### Summary
This commit updates the assignment method for the 'ball_hit' column in the DataFrame to use `.loc` instead of `.iloc`.

### Details
The previous implementation used `.iloc` for direct assignment, which triggered a `SettingWithCopyWarning`. This warning occurred due to potential issues with chained indexing and DataFrame views, which can lead to unintended behavior.

### Changes Made
- Replaced direct assignment with `.iloc` from `df_ball_positions['ball_hit'].iloc[i] = 1` to `.loc` as `df_ball_positions.loc[i, 'ball_hit'] = 1`.
- This update ensures that the assignment is applied directly to the DataFrame, avoiding the warning and following best practices for DataFrame modifications.

### Testing
- Verified that the new method prevents `SettingWithCopyWarning` and correctly updates the DataFrame.
- Ran existing tests to ensure that no new issues were introduced.
